### PR TITLE
MOD-398 - Add William Croxson to the Data Engineering Handbook

### DIFF
--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -22,4 +22,5 @@ The [harrison.ai](https://www.harrison.ai) data engineering team is currently co
 |         [Ryan Kelly](https://github.com/rfk)         |  Senior Software Engineer  |
 |      [Tim Leslie](https://github.com/timleslie)      |  Senior Software Engineer  |
 |      [Issa Moussa](https://github.com/comozo)        | Senior Solutions Architect |
+|    [William Croxson](https://github.com/peasee)      |      Software Engineer     |
 |                     *Now Hiring*                     | Senior Solutions Architect |


### PR DESCRIPTION
## Related Tasks

No relations.

## Depends on

No dependencies.

## What

I've added William Croxson to the about page of the Data Engineering Handbook.

## Why

These changes are required as William Croxson is now part of the team.

## Changes
docs: add william croxson to the handbook #MOD-398