### PR TITLE
chore: add Daniel Carrion

### DIFF
--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -23,4 +23,4 @@ The [harrison.ai](https://www.harrison.ai) data engineering team is currently co
 |      [Tim Leslie](https://github.com/timleslie)      |  Senior Software Engineer  |
 |      [Issa Moussa](https://github.com/comozo)        | Senior Solutions Architect |
 |    [William Croxson](https://github.com/peasee)      |      Software Engineer     |
-|                     *Now Hiring*                     | Senior Solutions Architect |
+|   [Daniel Carrion](https://github.com/dcarrion87)    | Senior Solutions Architect |


### PR DESCRIPTION
## Related Tasks

Daniel Carrion onboarding. JIRA inaccessible when created. 

## Depends on


## What

Add Daniel Carrion to the about page

## Why

Daniel Carrion onboarding.

## Concerns

## Notes

* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.